### PR TITLE
Enables publishing of ESM variant next to CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/nickwaelkens/ra-language-dutch/issues"
   },
   "contributors": [
-    "Pim Schaaf"
+    "Pim Schaaf",
+    "Maik Diepenbroek"
   ],
   "homepage": "https://github.com/nickwaelkens/ra-language-dutch#readme",
   "keywords": [
@@ -24,8 +25,7 @@
   },
   "files": [
     "*.md",
-    "lib",
-    "esm",
+    "dist",
     "src"
   ],
   "main": "dist/cjs/index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,13 @@
     "outDir": "lib",
     "rootDir": "src",
     "declaration": true,
+    "declarationMap": true,
     "allowJs": false,
     "target": "ES5",
     "module": "commonjs",
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es2017", "dom"],
     "jsx": "react",
-    "noImplicitAny": false ,
+    "noImplicitAny": false,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Adds dist folder to files array in package.json to ensure the commonJS and ESM build variant get published. Also enabled generation of sourcemaps for developer friendlyness.