### PR TITLE
Added missing translation for message.clear_array_input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ const dutchMessages: TranslationMessages = {
             bulk_update_content:
                 'Weet u zeker dat u dit %{name} wilt updaten? |||| Weet u zeker dat u deze %{smart_count} items wilt updaten?',
             bulk_update_title: 'Update %{name} |||| Update %{smart_count} %{name}',
+            clear_array_input: 'Weet u zeker dat u de hele lijst wilt wissen?',
             delete_content: 'Weet u zeker dat u dit item wilt verwijderen?',
             delete_title: '%{name} #%{id} verwijderen',
             details: 'Details',


### PR DESCRIPTION
I've noticed a missing translation. This PR adds `message.clear_array_input`

![image](https://github.com/nickwaelkens/ra-language-dutch/assets/3153052/411107d2-d97f-4b6e-8c91-6570cd5c3495)
